### PR TITLE
Move transformations to sourceNodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Changed
+
+* Transformations are applied in `sourceNodes` which allows us to put enriched content directly on the node. Hence `fields { src } on CmsImage` becomes just `src on CmsImage`.
+
 # [0.1.1] - 2019-01-08
 
 ## Added

--- a/src/gatsby-node.test.js
+++ b/src/gatsby-node.test.js
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 import * as pagesIndexFixtures from './__test__/fixtures/pages-index';
 import * as pagesFixtures from './__test__/fixtures/pages';
 
-import { sourceNodes, onCreateNode } from './gatsby-node';
+import { sourceNodes } from './gatsby-node';
 
 jest.mock('node-fetch', () => jest.fn());
 
@@ -71,6 +71,7 @@ describe('sourceNodes', () => {
         contentDigest: 'component/text-49bbbd10-8bdc-48de-9bcf-a46f56195c1b',
       },
       content: 'Cats write short articles',
+      html: '<p>Cats write short articles</p>\n',
     });
 
     expect(createNode).toHaveBeenCalledWith({
@@ -83,56 +84,6 @@ describe('sourceNodes', () => {
         contentDigest: 'Page-4007a470-232b-11ea-aaef-0800200c9a66',
       },
       slug: 'the-cat-post',
-    });
-  });
-});
-
-describe('onCreateNode', () => {
-  function subject(node) {
-    const actions = {
-      createNodeField: jest.fn(),
-    };
-
-    const pluginOptions = {
-      endpoint: 'http://example.net',
-    };
-
-    onCreateNode({ node, actions }, pluginOptions);
-
-    return actions;
-  }
-
-  test('it adds an absolute URL to Image resources', () => {
-    const node = {
-      url: '/some/path',
-      internal: {
-        type: 'CmsImage',
-      },
-    };
-
-    const { createNodeField } = subject(node);
-
-    expect(createNodeField).toHaveBeenCalledWith({
-      node,
-      name: 'src',
-      value: 'http://example.net/some/path',
-    });
-  });
-
-  test('it adds compiled HTML to TextBlock resources', () => {
-    const node = {
-      content: '*foo*',
-      internal: {
-        type: 'CmsComponentText',
-      },
-    };
-
-    const { createNodeField } = subject(node);
-
-    expect(createNodeField).toHaveBeenCalledWith({
-      node,
-      name: 'html',
-      value: '<p><em>foo</em></p>\n',
     });
   });
 });

--- a/src/node-helpers.js
+++ b/src/node-helpers.js
@@ -13,7 +13,7 @@ const nodeType = resource => `Cms${camelizeResourceType(resource.type)}`;
 
 const nodeId = resource => `${resource.type}-${resource.id}`;
 
-const nodeFromResource = (resource, createContentDigest) => {
+const nodeFromResource = resource => {
   const relationships = {};
   Object.entries(resource.relationships || {})
     .filter(arr => 'data' in arr[1] && arr[1].data !== null)
@@ -37,7 +37,6 @@ const nodeFromResource = (resource, createContentDigest) => {
 
   const internal = {
     type: nodeType(resource),
-    contentDigest: createContentDigest(node),
   };
 
   return { ...node, internal };

--- a/src/node-helpers.test.js
+++ b/src/node-helpers.test.js
@@ -10,9 +10,7 @@ describe('nodeFromResource', () => {
       ...resourceProps,
     };
 
-    const createContentDigest = x => x.id;
-
-    return nodeFromResource(resource, createContentDigest);
+    return nodeFromResource(resource);
   }
 
   test('builds Cms-prefixed Node types from resource types', () => {

--- a/src/node-transformations.js
+++ b/src/node-transformations.js
@@ -1,0 +1,25 @@
+import markdownConverter from './markdown-converter';
+
+const addNodeProps = (type, func) => {
+  return (node, pluginOptions) => {
+    if (node.internal.type !== type) return node;
+
+    const newProps = func(node, pluginOptions);
+
+    return {
+      ...node,
+      ...newProps,
+    };
+  };
+};
+
+export const addSrcToImage = addNodeProps(
+  'CmsImage',
+  (node, pluginOptions) => ({ src: `${pluginOptions.endpoint}${node.url}` })
+);
+
+export const addHtmlToTextBlock = addNodeProps('CmsComponentText', node => ({
+  html: markdownConverter.render(node.content),
+}));
+
+export default [addSrcToImage, addHtmlToTextBlock];

--- a/src/node-transformations.test.js
+++ b/src/node-transformations.test.js
@@ -1,0 +1,43 @@
+import { addSrcToImage, addHtmlToTextBlock } from './node-transformations';
+
+describe('addSrcToImage', () => {
+  function subject(node) {
+    const pluginOptions = {
+      endpoint: 'http://example.net',
+    };
+
+    return addSrcToImage(node, pluginOptions);
+  }
+
+  test('it adds an absolute URL to Image resources', () => {
+    const node = {
+      url: '/some/path',
+      internal: {
+        type: 'CmsImage',
+      },
+    };
+
+    const transformed = subject(node);
+
+    expect(transformed.src).toEqual('http://example.net/some/path');
+  });
+});
+
+describe('addHtmlToTextBlock', () => {
+  function subject(node) {
+    return addHtmlToTextBlock(node);
+  }
+
+  test('it adds compiled HTML to TextBlock resources', () => {
+    const node = {
+      content: '*foo*',
+      internal: {
+        type: 'CmsComponentText',
+      },
+    };
+
+    const transformed = subject(node);
+
+    expect(transformed.html).toEqual('<p><em>foo</em></p>\n');
+  });
+});


### PR DESCRIPTION
This PR moves the transformations to `sourceNodes` to get rid of the unnecessary `fields` nesting. `onCreateNode` is intended to be used by foreign plugins that want to add data/nodes later on.